### PR TITLE
chore: remove dangerous clean slate option from FTP deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,4 +40,3 @@ jobs:
           protocol: ftps
           local-dir: ./out/
           server-dir: /public_html/
-          dangerous-clean-slate: true  # Removes all files before upload


### PR DESCRIPTION
removed dangerous-clean-slate now that deployment has been tested and works